### PR TITLE
Make MaxDuration nullable, it will assign only when audio is initialized

### DIFF
--- a/lib/src/voice_message_view.dart
+++ b/lib/src/voice_message_view.dart
@@ -152,8 +152,10 @@ class VoiceMessageView extends StatelessWidget {
                   children: [
                     const SizedBox(height: 8),
                     _noises(newTHeme),
-                    const SizedBox(height: 4),
-                    Text(controller.remindingTime, style: counterTextStyle),
+                    if(controller.maxDuration!=null)...[
+                      const SizedBox(height: 4),
+                      Text(controller.remindingTime, style: counterTextStyle),
+                    ]else const SizedBox(height: 8),
                   ],
                 ),
               ),


### PR DESCRIPTION
I made `maxDuration` in the `VoiceController` nullable because we don't need it until the player is initialized. Passing a default value upfront is unnecessarily complex. Also, there's no need to manually retrieve the duration again if the SDK already handles it when creating the instance.

As for the wave visualization, I’ve set a default duration of 24 seconds for now, which can be adjusted later if needed.